### PR TITLE
Fix error when validating new member in CP

### DIFF
--- a/src/Http/Controllers/CP/MembersController.php
+++ b/src/Http/Controllers/CP/MembersController.php
@@ -125,7 +125,7 @@ class MembersController extends UsersController
 
         $fields = $blueprint->fields()->only($only)->except($except)->addValues($request->all());
 
-        $fields->validate(['email' => 'required|email|unique_user_value']);
+        $fields->validate(['email' => ['required', 'email', new UniqueUserValue()]]);
 
         $values = $fields->process()->values()->except(['email', 'groups', 'roles', 'password']);
 


### PR DESCRIPTION
The store method of the MembersController was still using the older string style alias for unique user validation. This small change updates it to the new class-based syntax.